### PR TITLE
fix goreleaser build flags

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,13 +5,15 @@ builds:
 - id: dcm
   main: ./
   binary: dcm
+  flags:
+  - -tags=json1
   asmflags:
   - all=-trimpath={{ dir .Env.PWD }}
   gcflags:
   - all=-trimpath={{ dir .Env.PWD }}
   ldflags:
-  - -s
-  - -w
+  - -s -w
+  - -extldflags=-static
   - -X {{ .Env.REPO }}/internal/version.GitVersion={{.Env.GIT_VERSION}}
   - -X {{ .Env.REPO }}/internal/version.GitCommit={{.Env.GIT_COMMIT}}
   - -X {{ .Env.REPO }}/internal/version.GitCommitTime={{.Env.GIT_COMMIT_TIME}}

--- a/Makefile
+++ b/Makefile
@@ -14,11 +14,12 @@ GOLANGCILINT_VERSION = 1.42.1
 GORELEASER_VERSION = 0.179.0
 
 GO_BUILD_ARGS = \
+  -tags=json1 \
   -gcflags "all=-trimpath=$(shell dirname $(shell pwd))" \
   -asmflags "all=-trimpath=$(shell dirname $(shell pwd))" \
   -ldflags " \
-    -s \
-    -w \
+    -s -w \
+    -extldflags=static \
     -X '$(REPO)/internal/version.GitVersion=$(GIT_VERSION)' \
     -X '$(REPO)/internal/version.GitCommit=$(GIT_COMMIT)' \
     -X '$(REPO)/internal/version.GitCommitTime=$(GIT_COMMIT_TIME)' \


### PR DESCRIPTION
Add flags: `-tags=json1 -ldflags='-extldflags=-static'`, which is required to support sqlite integration.